### PR TITLE
add delete alias

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ var routeMethods = {
   post: 'post',
   put: 'put',
   delete: 'delete',
+  del: 'delete',
   patch: 'patch',
   all: '*'
 }


### PR DESCRIPTION
`delete` is a reserved keyword and thus not allowed in many environments, this PR simply creates `del` export as an alternative.